### PR TITLE
Fix param flow

### DIFF
--- a/camelot/lattice.py
+++ b/camelot/lattice.py
@@ -117,8 +117,8 @@ class Lattice:
         hmask, h_segments = find_lines(threshold, direction='horizontal',
             scale=self.scale)
 
-        if self.table_area:
-            if self.fill:
+        if self.table_area is not None:
+            if self.fill is not None:
                 if len(self.table_area) != len(self.fill):
                     raise ValueError("message")
             areas = []
@@ -226,7 +226,7 @@ class Lattice:
             score = get_score([[50, rerror], [50, cerror]])
             table_data['score'] = score
 
-            if self.fill:
+            if self.fill is not None:
                 table = fill_spanning(table, fill=self.fill[table_no])
             ar = table.get_list()
             if table_rotation == 'left':

--- a/camelot/stream.py
+++ b/camelot/stream.py
@@ -231,11 +231,11 @@ class Stream:
             self.debug_text = [(t.x0, t.y0, t.x1, t.y1) for t in text]
             return None
 
-        if self.table_area:
-            if self.columns:
+        if self.table_area is not None:
+            if self.columns is not None:
                 if len(self.table_area) != len(self.columns):
                     raise ValueError("message")
-            if self.ncolumns:
+            if self.ncolumns is not None:
                 if len(self.table_area) != len(self.ncolumns):
                     raise ValueError("message")
             table_bbox = {}
@@ -269,7 +269,7 @@ class Stream:
             elements = [len(r) for r in rows_grouped]
 
             guess = False
-            if self.columns and self.columns[table_no] != "":
+            if self.columns is not None and self.columns[table_no] != "":
                 # user has to input boundary columns too
                 # take (0, width) by default
                 # similar to else condition
@@ -278,7 +278,7 @@ class Stream:
                 cols = [(float(cols[i]), float(cols[i + 1]))
                         for i in range(0, len(cols) - 1)]
             else:
-                if self.ncolumns and self.ncolumns[table_no] != -1:
+                if self.ncolumns is not None and self.ncolumns[table_no] != -1:
                     ncols = self.ncolumns[table_no]
                     cols = [(t.x0, t.x1)
                         for r in rows_grouped if len(r) == ncols for t in r]


### PR DESCRIPTION
Previously, I was increasing the length of tolerance parameters based on `len(self.table_area)`, but this was wrong as `table_area` won't always be specified. Think of more flows where some error would be raised.
