### PR TITLE
Creates a new variable that stores a lowercase version of the filename

### DIFF
--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -26,7 +26,8 @@ class PDFHandler(object):
     """
     def __init__(self, filename, pages='1'):
         self.filename = filename
-        if not self.filename.endswith('.pdf'):
+        filename_checking = filename.lower()
+        if not filename_checking.endswith('.pdf'):
             raise NotImplementedError("File format not supported")
         self.pages = self._get_pages(self.filename, pages)
 


### PR DESCRIPTION
PDF type checking fails if you have a PDF with a extension like: .PDF, .PdF, PDf, pdF.

This lowercase version of the variable should identify better if it's a PDF file.