### PR TITLE
Revert "[MRG] Change table to grid"

### DIFF
--- a/docs/user/advanced.rst
+++ b/docs/user/advanced.rst
@@ -80,7 +80,7 @@ Let's plot the table (to see if it was detected correctly or not). This plot typ
 
 ::
 
-    >>> camelot.plot(tables[0], kind='grid')
+    >>> camelot.plot(tables[0], kind='table')
     >>> plt.show()
 
 .. figure:: ../_static/png/plot_table.png
@@ -284,7 +284,7 @@ Let's plot the table for this PDF.
 ::
 
     >>> tables = camelot.read_pdf('short_lines.pdf')
-    >>> camelot.plot(tables[0], kind='grid')
+    >>> camelot.plot(tables[0], kind='table')
     >>> plt.show()
 
 .. figure:: ../_static/png/short_lines_1.png
@@ -296,7 +296,7 @@ Clearly, the smaller lines separating the headers, couldn't be detected. Let's t
 ::
 
     >>> tables = camelot.read_pdf('short_lines.pdf', line_size_scaling=40)
-    >>> camelot.plot(tables[0], kind='grid')
+    >>> camelot.plot(tables[0], kind='table')
     >>> plt.show()
 
 .. figure:: ../_static/png/short_lines_2.png


### PR DESCRIPTION
Reverts socialcopsdev/camelot#196.

Strangely, this change makes the build (which was passing before the commit) fail on Python 2.7. Reverting to see if it was indeed the change that failed the build.