### PR TITLE
[MRG] Sort TableList by order of tables in PDF

### DIFF
--- a/camelot/core.py
+++ b/camelot/core.py
@@ -329,6 +329,13 @@ class Table(object):
     def __repr__(self):
         return '<{} shape={}>'.format(self.__class__.__name__, self.shape)
 
+    def __lt__(self, other):
+        if self.page == other.page:
+            if self.order < other.order:
+                return True
+        if self.page < other.page:
+            return True
+
     @property
     def data(self):
         """Returns two-dimensional list of strings in table.

--- a/camelot/handlers.py
+++ b/camelot/handlers.py
@@ -161,4 +161,4 @@ class PDFHandler(object):
                 t = parser.extract_tables(p, suppress_stdout=suppress_stdout,
                                           layout_kwargs=layout_kwargs)
                 tables.extend(t)
-        return TableList(tables)
+        return TableList(sorted(tables))

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -251,14 +251,14 @@ def test_arabic():
 
 
 def test_table_order():
-    def _mk_table(page, order):
+    def _make_table(page, order):
         t = Table([], [])
         t.page = page
         t.order = order
         return t
 
     table_list = TableList(
-        [_mk_table(2, 1), _mk_table(1, 1), _mk_table(3, 4), _mk_table(1, 2)]
+        [_make_table(2, 1), _make_table(1, 1), _make_table(3, 4), _make_table(1, 2)]
     )
 
     assert [(t.page, t.order) for t in sorted(table_list)] == [

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -5,6 +5,7 @@ import os
 import pandas as pd
 
 import camelot
+from camelot.core import Table, TableList
 
 from .data import *
 
@@ -247,3 +248,28 @@ def test_arabic():
     filename = os.path.join(testdir, "tabula/arabic.pdf")
     tables = camelot.read_pdf(filename)
     assert df.equals(tables[0].df)
+
+
+def test_table_order():
+    def _mk_table(page, order):
+        t = Table([], [])
+        t.page = page
+        t.order = order
+        return t
+
+    table_list = TableList(
+        [_mk_table(2, 1), _mk_table(1, 1), _mk_table(3, 4), _mk_table(1, 2)]
+    )
+
+    assert [(t.page, t.order) for t in sorted(table_list)] == [
+        (1, 1),
+        (1, 2),
+        (2, 1),
+        (3, 4),
+    ]
+    assert [(t.page, t.order) for t in sorted(table_list, reverse=True)] == [
+        (3, 4),
+        (2, 1),
+        (1, 2),
+        (1, 1),
+    ]


### PR DESCRIPTION
This PR fixes https://github.com/socialcopsdev/camelot/issues/277

* c019e58 is fairly easy, and is useful for some cases where the `Table` objects have got mixed up for some reason, or where reversing them is useful.

* 8446271 I'm less sure about. When I opened the issue I thought I'd found a PDF that causes camelot to return tables in an order not defined in the PDF. I can't reproduce this, so I can't make a regression test for it. Very happy if you'd like me to pick that commit out, although I don't think it's doing any harm as it stands.