### PR TITLE
[MRG] Detect Ghostscript on Cygwin

### DIFF
--- a/camelot/ext/ghostscript/_gsprint.py
+++ b/camelot/ext/ghostscript/_gsprint.py
@@ -230,7 +230,10 @@ if sys.platform == 'win32':
     libgs = windll.LoadLibrary(libgs)
 else:
     try:
-        libgs = cdll.LoadLibrary('libgs.so')
+        if sys.platform == 'cygwin':
+            libgs = cdll.LoadLibrary('cyggs-*.dll')
+        else:
+            libgs = cdll.LoadLibrary('libgs.so')
     except OSError:
         # shared object file not found
         import ctypes.util


### PR DESCRIPTION
Hi,
This change is needed to detect libgs -- named cyggs on Cygwin -- and allow proper operation of the module on this platform.