### PR TITLE
[MRG] Update README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,4 +132,4 @@ Camelot uses [Semantic Versioning](https://semver.org/). For the available versi
 
 This project is licensed under the MIT License, see the [LICENSE](https://github.com/camelot-dev/camelot/blob/master/LICENSE) file for details.
 
-<img src="http://i65.tinypic.com/9h4ajs.png" align="centre" />
+<img src="https://user-images.githubusercontent.com/408863/66741678-a78ab780-ee93-11e9-8d90-b274af222339.png" align="centre" />


### PR DESCRIPTION
- Use footer image on Github itself instead of a third party service
- Got the original image from [Wayback Archive](https://web.archive.org/web/*/https://github.com/atlanhq/camelot)
- Fix for #380 