### PR TITLE
Fix passing resolution argument to ghostscript in lattice parser

### DIFF
--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -212,8 +212,8 @@ class Lattice(BaseParser):
         from ..ext.ghostscript import Ghostscript
 
         self.imagename = "".join([self.rootname, ".png"])
-        gs_call = "-q -sDEVICE=png16m -o {} -r300 {}".format(
-            self.imagename, self.filename
+        gs_call = "-q -sDEVICE=png16m -o {} -r{} {}".format(
+            self.imagename, self.resolution, self.filename
         )
         gs_call = gs_call.encode().split()
         null = open(os.devnull, "wb")


### PR DESCRIPTION
The lattice parser has a resolution attribute that is never used. A default value of 300 is instead passed to ghostscript.
I changed the ghostscript command to use `self.resolution` as it was intended.