### PR TITLE
[MRG] Change import and usage according to pdfminer latest changes

### DIFF
--- a/camelot/utils.py
+++ b/camelot/utils.py
@@ -16,7 +16,7 @@ import numpy as np
 from pdfminer.pdfparser import PDFParser
 from pdfminer.pdfdocument import PDFDocument
 from pdfminer.pdfpage import PDFPage
-from pdfminer.pdfpage import PDFTextExtractionNotAllowed
+from pdfminer.pdfpage import PDFTextExtractionNotAllowedError
 from pdfminer.pdfinterp import PDFResourceManager
 from pdfminer.pdfinterp import PDFPageInterpreter
 from pdfminer.converter import PDFPageAggregator
@@ -794,7 +794,7 @@ def get_page_layout(
         parser = PDFParser(f)
         document = PDFDocument(parser)
         if not document.is_extractable:
-            raise PDFTextExtractionNotAllowed
+            raise PDFTextExtractionNotAllowedError
         laparams = LAParams(
             char_margin=char_margin,
             line_margin=line_margin,


### PR DESCRIPTION
## Description

Camelot's dependency **pdfminer** has recently published a new version ([20200720](https://github.com/pdfminer/pdfminer.six/releases/tag/20200720)).

A minor change about a class name induces that camelot can't work anymore and fail every time. 

Below, a screenshot of the error that is available in the trace :

<img width="1341" alt="image" src="https://user-images.githubusercontent.com/34269296/88070419-f1b36e80-cb72-11ea-8a37-c5b39c3271b0.png">

## Source

As visible in this [diff](https://github.com/pdfminer/pdfminer.six/compare/20200517...20200720#diff-7b8996b6e630ef8e86e17a8d0df3c78cL44), from version 20200517 to version 20200720, the class `PDFTextExtractionNotAllowed` has been renamed to `PDFTextExtractionNotAllowedError`.

Perhaps, as we can see [here](https://github.com/atlanhq/camelot/blob/0efb3ca1b0ad382c2ed2f5c503c16901b3251421/camelot/utils.py#L19) and [here](https://github.com/atlanhq/camelot/blob/0efb3ca1b0ad382c2ed2f5c503c16901b3251421/camelot/utils.py#L797), camelot still uses the previous syntax. 

Moreover, as camelot has defined it pdfminer dependency in its [requirements.txt](https://github.com/atlanhq/camelot/blob/master/requirements.txt#L7), it automatically updated to the latest pdfminer version.

## Solution

To resolve this problem, we just have to change the class name used in camelot to the new one.
