### PR TITLE
split_text IndexError fix

### DIFF
--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -155,24 +155,28 @@ class Lattice(BaseParser):
         """
         indices = []
         for r_idx, c_idx, text in idx:
-            for d in shift_text:
-                if d == "l":
-                    if t.cells[r_idx][c_idx].hspan:
-                        while not t.cells[r_idx][c_idx].left:
-                            c_idx -= 1
-                if d == "r":
-                    if t.cells[r_idx][c_idx].hspan:
-                        while not t.cells[r_idx][c_idx].right:
-                            c_idx += 1
-                if d == "t":
-                    if t.cells[r_idx][c_idx].vspan:
-                        while not t.cells[r_idx][c_idx].top:
-                            r_idx -= 1
-                if d == "b":
-                    if t.cells[r_idx][c_idx].vspan:
-                        while not t.cells[r_idx][c_idx].bottom:
-                            r_idx += 1
-            indices.append((r_idx, c_idx, text))
+            try:
+                for d in shift_text:
+                    if d == "l":
+                        if t.cells[r_idx][c_idx].hspan:
+                            while not t.cells[r_idx][c_idx].left:
+                                c_idx -= 1
+                    if d == "r":
+                        if t.cells[r_idx][c_idx].hspan:
+                            while not t.cells[r_idx][c_idx].right:
+                                c_idx += 1
+                    if d == "t":
+                        if t.cells[r_idx][c_idx].vspan:
+                            while not t.cells[r_idx][c_idx].top:
+                                r_idx -= 1
+                    if d == "b":
+                        if t.cells[r_idx][c_idx].vspan:
+                            while not t.cells[r_idx][c_idx].bottom:
+                                r_idx += 1
+            except IndexError:
+                print(r_idx, c_idx)
+            else:
+                indices.append((r_idx, c_idx, text))
         return indices
 
     @staticmethod

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -156,25 +156,22 @@ class Lattice(BaseParser):
         indices = []
         for r_idx, c_idx, text in idx:
             for d in shift_text:
-                try:
-                    if d == "l":
-                        if t.cells[r_idx][c_idx].hspan:
-                            while not t.cells[r_idx][c_idx].left:
-                                c_idx -= 1
-                    if d == "r":
-                        if t.cells[r_idx][c_idx].hspan:
-                            while not t.cells[r_idx][c_idx].right:
-                                c_idx += 1
-                    if d == "t":
-                        if t.cells[r_idx][c_idx].vspan:
-                            while not t.cells[r_idx][c_idx].top:
-                                r_idx -= 1
-                    if d == "b":
-                        if t.cells[r_idx][c_idx].vspan:
-                            while not t.cells[r_idx][c_idx].bottom:
-                                r_idx += 1
-                except IndexError:
-                    continue
+                if d == "l":
+                    if t.cells[r_idx][c_idx].hspan:
+                        while not t.cells[r_idx][c_idx].left:
+                            c_idx -= 1
+                if d == "r":
+                    if t.cells[r_idx][c_idx].hspan:
+                        while not t.cells[r_idx][c_idx].right:
+                            c_idx += 1
+                if d == "t":
+                    if t.cells[r_idx][c_idx].vspan:
+                        while not t.cells[r_idx][c_idx].top:
+                            r_idx -= 1
+                if d == "b":
+                    if t.cells[r_idx][c_idx].vspan:
+                        while not t.cells[r_idx][c_idx].bottom:
+                            r_idx += 1
             indices.append((r_idx, c_idx, text))
         return indices
 

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -174,7 +174,8 @@ class Lattice(BaseParser):
                             while not t.cells[r_idx][c_idx].bottom:
                                 r_idx += 1
             except IndexError:
-                print(r_idx, c_idx)
+                # TODO: probably there should be some warning
+                pass
             else:
                 indices.append((r_idx, c_idx, text))
         return indices

--- a/camelot/parsers/lattice.py
+++ b/camelot/parsers/lattice.py
@@ -156,22 +156,25 @@ class Lattice(BaseParser):
         indices = []
         for r_idx, c_idx, text in idx:
             for d in shift_text:
-                if d == "l":
-                    if t.cells[r_idx][c_idx].hspan:
-                        while not t.cells[r_idx][c_idx].left:
-                            c_idx -= 1
-                if d == "r":
-                    if t.cells[r_idx][c_idx].hspan:
-                        while not t.cells[r_idx][c_idx].right:
-                            c_idx += 1
-                if d == "t":
-                    if t.cells[r_idx][c_idx].vspan:
-                        while not t.cells[r_idx][c_idx].top:
-                            r_idx -= 1
-                if d == "b":
-                    if t.cells[r_idx][c_idx].vspan:
-                        while not t.cells[r_idx][c_idx].bottom:
-                            r_idx += 1
+                try:
+                    if d == "l":
+                        if t.cells[r_idx][c_idx].hspan:
+                            while not t.cells[r_idx][c_idx].left:
+                                c_idx -= 1
+                    if d == "r":
+                        if t.cells[r_idx][c_idx].hspan:
+                            while not t.cells[r_idx][c_idx].right:
+                                c_idx += 1
+                    if d == "t":
+                        if t.cells[r_idx][c_idx].vspan:
+                            while not t.cells[r_idx][c_idx].top:
+                                r_idx -= 1
+                    if d == "b":
+                        if t.cells[r_idx][c_idx].vspan:
+                            while not t.cells[r_idx][c_idx].bottom:
+                                r_idx += 1
+                except IndexError:
+                    continue
             indices.append((r_idx, c_idx, text))
         return indices
 


### PR DESCRIPTION
Some files throws IndexError while reading file via read_pdf with split_text set to True.
File example: https://disk.yandex.ru/i/sMcNUwU4VoOENQ
https://github.com/atlanhq/camelot/issues/443

The approach is quite straightforward but works in my cases